### PR TITLE
chore: 🤖 bump merge dependency to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "merge": "2.1.0",
+    "merge": "2.1.1",
     "prop-types": "^15.7.2"
   },
   "homepage": "https://github.com/CoderJWYang/react-native-alphabet-sectionlist#readme",


### PR DESCRIPTION
bump the merge library, which address the whitesource vulnerable to Prototype Pollution issue.